### PR TITLE
release-20260219

### DIFF
--- a/src/pages/campaigns/components/campaignForm/FormProvider.tsx
+++ b/src/pages/campaigns/components/campaignForm/FormProvider.tsx
@@ -406,7 +406,7 @@ const FormProvider = ({
               body: {
                 ...body,
                 duplicate: duplicate,
-                notify_everyone: 1,
+                notify_everyone: 0, // disabled because in duplication process if customer is different we're going to add unwanted users to the notification list.
               },
             }).unwrap();
             if (!resp.id) {


### PR DESCRIPTION
This pull request makes a minor adjustment to the `FormProvider` component, specifically related to campaign duplication. The change disables the "notify everyone" feature during the duplication process to prevent unintended notifications to users when the customer is different.

* Changed `notify_everyone` from `1` to `0` in the campaign duplication request body to avoid notifying unwanted users.