### PR TITLE
release-20260226

### DIFF
--- a/src/pages/campaigns/components/campaignForm/FormProvider.tsx
+++ b/src/pages/campaigns/components/campaignForm/FormProvider.tsx
@@ -2,6 +2,7 @@ import { Formik } from "@appquality/appquality-design-system";
 import { useMemo } from "react";
 import { useHistory } from "react-router-dom";
 import { addMessage } from "src/redux/siteWideMessages/actionCreators";
+
 import {
   GetDossiersByCampaignApiResponse,
   PostDossiersApiArg,
@@ -67,6 +68,11 @@ export interface NewCampaignValues {
   autoApply?: boolean;
   autoApprove?: boolean;
 }
+
+const stripHtml = (html: string): string => {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  return doc.body.textContent ?? "";
+};
 
 const useGetInitialCufCriteria = ({
   dossier,
@@ -167,7 +173,7 @@ const FormProvider = ({
     languages: dossier?.languages?.map((lang) => lang.name) || [],
     description: dossier?.description || "",
     productLink: dossier?.productLink || "",
-    goal: dossier?.goal || "",
+    goal: dossier?.goal ? stripHtml(dossier.goal).trim() : "",
     outOfScope: dossier?.outOfScope || "",
     deviceRequirements: dossier?.deviceRequirements || "",
     targetNotes: dossier?.target?.notes || "",


### PR DESCRIPTION
This pull request introduces a minor update to the `FormProvider` component to improve how the campaign goal is handled. The main change is that any HTML tags are stripped from the `goal` field when initializing form values, ensuring only plain text is used.

**Form value sanitization:**

* Added a `stripHtml` utility function to remove HTML tags from strings, and updated the initialization of the `goal` field in the form to use this function, ensuring that only plain text (without HTML markup) is set for the `goal` value. [[1]](diffhunk://#diff-85cdafe3510f6c201b18df121a3a3fabb259b65a45ae508d97a1ee788f7b84b0R72-R76) [[2]](diffhunk://#diff-85cdafe3510f6c201b18df121a3a3fabb259b65a45ae508d97a1ee788f7b84b0L170-R176)